### PR TITLE
Fixes brush size control typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To create a canvas of a specific size, use the url hash, like `index.html#720x40
 
 ### Brush
 
-- `z`: Increase Size
-- `x`: Decrease Size
+- `x`: Increase Size
+- `z`: Decrease Size
 - `Shift`: Erase
 - `Alt`: Drag
 


### PR DESCRIPTION
Took me a while to notice that the controls were backwards here.